### PR TITLE
add basic fee model to incentivize relayers

### DIFF
--- a/contracts/IRelay.sol
+++ b/contracts/IRelay.sol
@@ -65,7 +65,6 @@ interface IRelay {
      * @param proof Merkle proof
      * @param confirmations Required confirmations (insecure)
      * @param insecure Check custom inclusion confirmations
-     * @return True if txid is included, false otherwise
      */
     function verifyTx(
         uint32 height,
@@ -75,5 +74,5 @@ interface IRelay {
         bytes calldata proof,
         uint256 confirmations,
         bool insecure
-    ) external view returns (bool);
+    ) external payable;
 }

--- a/contracts/TestRelay.sol
+++ b/contracts/TestRelay.sol
@@ -29,7 +29,10 @@ contract TestRelay is Relay {
     /**
      * @dev Override to remove the difficulty check
      */
-    function _submitBlockHeader(bytes memory header) internal override {
+    function _submitBlockHeader(address payable author, bytes memory header)
+        internal
+        override
+    {
         require(header.length == 80, ERR_INVALID_HEADER_SIZE);
 
         bytes32 hashPrevBlock = header.extractPrevBlockLE().toBytes32();
@@ -62,9 +65,9 @@ contract TestRelay is Relay {
             chainId = _incrementChainCounter();
             _initializeFork(hashCurrBlock, hashPrevBlock, chainId, height);
 
-            _storeBlockHeader(hashCurrBlock, height, chainId);
+            _storeBlockHeader(author, hashCurrBlock, height, chainId);
         } else {
-            _storeBlockHeader(hashCurrBlock, height, chainId);
+            _storeBlockHeader(author, hashCurrBlock, height, chainId);
 
             if (chainId == MAIN_CHAIN_ID) {
                 _bestBlock = hashCurrBlock;

--- a/test/gas.test.ts
+++ b/test/gas.test.ts
@@ -32,7 +32,7 @@ describe('Gas', () => {
       await relay.deployTransaction.wait(1)
     ).gasUsed?.toNumber();
     // console.log(`Deploy: ${deployCost}`);
-    expect(deployCost).to.be.lt(2_000_000);
+    expect(deployCost).to.be.lt(2_300_000);
 
     const result = await relay.submitBlockHeader(header1);
     const updateCost = (await result.wait(1)).gasUsed?.toNumber();

--- a/test/proof.test.ts
+++ b/test/proof.test.ts
@@ -15,6 +15,8 @@ async function getBestBlockHeight(relay: Relay): Promise<number> {
   return height;
 }
 
+const verifyCostWei = 106000;
+
 function deploy(
   signer: Signer,
   header: Arrayish,
@@ -107,7 +109,8 @@ describe('Proofs', () => {
       genesisHeader,
       tx.intermediateNodes,
       0,
-      true
+      true,
+      {value: verifyCostWei}
     );
   });
 
@@ -124,7 +127,9 @@ describe('Proofs', () => {
       'hex'
     ).reverse();
 
-    await relay.verifyTx(height, 0, txId, header, [], 0, true);
+    await relay.verifyTx(height, 0, txId, header, [], 0, true, {
+      value: verifyCostWei
+    });
   });
 
   const testnet1 = {
@@ -162,7 +167,8 @@ describe('Proofs', () => {
       testnet1.header,
       '0x' + proof,
       0,
-      true
+      true,
+      {value: verifyCostWei}
     );
   });
 
@@ -201,7 +207,8 @@ describe('Proofs', () => {
       testnet2.header,
       '0x' + proof,
       0,
-      true
+      true,
+      {value: verifyCostWei}
     );
   });
 
@@ -239,7 +246,8 @@ describe('Proofs', () => {
       testnet3.header,
       '0x' + proof,
       0,
-      true
+      true,
+      {value: verifyCostWei}
     );
   });
 
@@ -279,7 +287,8 @@ describe('Proofs', () => {
       '0x' + mainnet1.header,
       '0x' + proof,
       0,
-      true
+      true,
+      {value: verifyCostWei}
     );
   });
 });


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Adds a rudimentary base fee payable in ETH for all verification requests in order to incentivize relayers to actually submit block headers. Also implements a simple setter, callable only by the contract creator. In the future we may want to consider some form of governance control for this (perhaps weighted by prior submissions).